### PR TITLE
Remove OptionSeller Commit Timelock

### DIFF
--- a/contracts/vaults/EarnVault/RibbonEarnVault.sol
+++ b/contracts/vaults/EarnVault/RibbonEarnVault.sol
@@ -344,7 +344,6 @@ contract RibbonEarnVault is
     function commitOptionSeller() external onlyOwner {
         require(pendingOptionSeller != address(0), "R51");
 
-        require(block.timestamp >= (lastOptionSellerChange + 3 days), "R10");
         optionSeller = pendingOptionSeller;
         pendingOptionSeller = address(0);
     }

--- a/test/RibbonEarnVault.ts
+++ b/test/RibbonEarnVault.ts
@@ -1067,21 +1067,11 @@ function behavesLikeRibbonOptionsVault(params: {
         ).to.be.revertedWith("R51");
       });
 
-      it("reverts when not waiting 72 hours for commit borrower", async function () {
-        assert.equal(await vault.optionSeller(), optionSeller);
-        await vault.connect(ownerSigner).setOptionSeller(owner);
-
-        await expect(
-          vault.connect(ownerSigner).commitOptionSeller()
-        ).to.be.revertedWith("R10");
-      });
-
       it("set new option seller", async function () {
         await vault.connect(ownerSigner).setOptionSeller(owner);
         assert.equal(await vault.optionSeller(), optionSeller);
         assert.equal(await vault.pendingOptionSeller(), owner);
-        // 72 hours
-        await time.increase(86400 * 3 + 1);
+
         await vault.connect(ownerSigner).commitOptionSeller();
         assert.equal(await vault.optionSeller(), owner);
         assert.equal(await vault.pendingOptionSeller(), constants.AddressZero);


### PR DESCRIPTION
Since we will be auctioning off the twin win counter-party on a weekly basis, we need flexibility to change the option seller on an hourly basis